### PR TITLE
chore: add pytest.ini (UTF-8 without BOM) and silence pytest-asyncio deprecation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+﻿[pytest]
+filterwarnings =
+    ignore::pytest.PytestDeprecationWarning:pytest_asyncio.plugin

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
-﻿[pytest]
+[pytest]
 filterwarnings =
     ignore::pytest.PytestDeprecationWarning:pytest_asyncio.plugin


### PR DESCRIPTION
## What & Why
- Add `pytest.ini` encoded as UTF-8 **without BOM** to fix:
  > ERROR: unexpected line: '\ufeff[pytest]'
- Silence `pytest_asyncio` deprecation noise via:
[pytest]
filterwarnings =
ignore::pytest.PytestDeprecationWarning:pytest_asyncio.plugin

markdown
Copy code

## Test Plan
- Local: `pytest -q` → 8 passed ✅
- CI: matrix on Ubuntu & Windows (Py 3.9/3.12) will run on this PR.

## Impact
- Low risk, config-only; no runtime code changes.

## Checklist
- [x] Pre-commit (black + ruff) passes
- [x] Tests green locally
