### PR TITLE
qa: add coverage in CI; PR template; CODEOWNERS; TestPyPI release wor…

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+branch = True
+source = a3d
+omit =
+    tests/*
+    .venv/*
+
+[report]
+skip_empty = True
+show_missing = True
+precision = 1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hamidbahri92

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## What & Why
+
+## Test Plan
+- [ ] Ran `pytest -q` locally
+- [ ] CI green
+
+## Checklist
+- [ ] `pre-commit run --all-files` clean
+- [ ] Docs/README updated if needed
+- [ ] No secrets/keys committed
+
+<!-- Link issues with closing keywords, e.g. Closes #123 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    name: Tests (Py${{ matrix.python }} · ${{ matrix.os }})
+    name: Tests (Py${{ matrix.python }} Â· ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -1,0 +1,30 @@
+name: Release (TestPyPI)
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*


### PR DESCRIPTION
What & Why
- Add coverage reporting in CI (pytest-cov)
- Add PR template and CODEOWNERS
- Add TestPyPI release workflow (tag-triggered)

Test Plan
- Local: `pytest -q` → all green
- CI: matrix (Win/Ubuntu, Py 3.9/3.12)

Checklist
- pre-commit (black+ruff) clean
- No secrets committed
- Uses Actions secret: TEST_PYPI_API_TOKEN
