### PR TITLE
fix(deps): add networkx to runtime dependencies; bump to 1.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
-# FILE: pyproject.toml
 [project]
 name = "aegis-qec"
-version = "1.0.3"
+version = "1.0.4"
 description = "Aegis: Hardware-Aware Quantum Error Correction Platform"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -9,21 +8,21 @@ requires-python = ">=3.9"
 authors = [{ name = "Hamid bahri" }]
 dependencies = [
   "numpy>=1.21",
+  "networkx>=3.0,<4.0",
 ]
 
 [project.optional-dependencies]
 full = [
   "matplotlib>=3.5",
   "pyarrow>=10.0",
-  "networkx>=3.0",
   "pytest>=7.0",
 ]
 mwpm = [
-  "networkx>=3.0"
+  "networkx>=3.0,<4.0"
 ]
 
 [project.urls]
-Repository = "https://github.com/your-username/aegis"
+Repository = "https://github.com/hamidbahri92/Aegis"
 
 [project.scripts]
 aegis-run = "main:main"


### PR DESCRIPTION
What & Why
- Runtime needs MWPM (networkx). Declare it as a required dependency.
- Bump version to 1.0.4 for publication.

Changes
- pyproject.toml: add "networkx>=3,<4" to [project.dependencies] and extras.

Test Plan
- pre-commit (black+ruff) ✔
- pytest -q → all green (8/8) ✔
- CI matrix (Win/Ubuntu, Py 3.9/3.12) will run on this PR.

Impact
- Low risk; packaging only. Users installing aegis-qec now automatically get networkx.
