### PR TITLE
packaging: include CLI py-modules; find a3d package; bump to 1.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "aegis-qec"
-version = "1.0.4"
+version = "1.0.5"
 description = "Aegis: Hardware-Aware Quantum Error Correction Platform"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 authors = [{ name = "Hamid bahri" }]
+
 dependencies = [
   "numpy>=1.21",
   "networkx>=3.0,<4.0",
@@ -29,6 +30,14 @@ aegis-run = "main:main"
 aegis-metrics = "main_metrics:main"
 aegis-threshold = "main_threshold:main"
 aegis-export-header = "main_export_header:main"
+
+# تضمین اینکه a3d بهعنوان پکیج و اسکریپتهای سطح-ریشه داخل wheel بیایند
+[tool.setuptools]
+include-package-data = true
+py-modules = ["main", "main_metrics", "main_threshold", "main_export_header"]
+
+[tool.setuptools.packages.find]
+include = ["a3d*"]
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]


### PR DESCRIPTION
## What & Why
- Include CLI modules in wheel via `tool.setuptools.py-modules` (main, main_metrics, main_threshold, main_export_header)
- Ensure `a3d` is discovered in builds (`tool.setuptools.packages.find`)
- Version bump to 1.0.5

## Test Plan
- Local: `pip install -e .[full] --prefer-binary`
  - `aegis-run` → runs
  - `aegis-metrics` → writes out/metrics.*
  - `aegis-threshold` → writes out/threshold.*
  - `aegis-export-header` → writes out/gkp_lut.h
- CI: green on Windows & Ubuntu (Py 3.9/3.12)

## Checklist
- [x] `pre-commit run --all-files` clean
- [x] No secrets committed
- [x] Docs/README can be updated after publish (usage of console scripts)
