### PR TITLE
ci: add Release (PyPI) workflow using Twine

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,33 @@
+name: Release (PyPI)
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m twine upload dist/*


### PR DESCRIPTION
## What & Why

## Test Plan
- [ ] Ran `pytest -q` locally
- [ ] CI green

## Checklist
- [ ] `pre-commit run --all-files` clean
- [ ] Docs/README updated if needed
- [ ] No secrets/keys committed

<!-- Link issues with closing keywords, e.g. Closes #123 -->